### PR TITLE
ControlMakeCommand - badly interpreted perimeter generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ class PostControl extends Control
                 ->should(function (Model $user, Model $model) {
                     return true;
                 })
-                ->scoutQuery(function (\Laravel\Scout\Builder $query, Model $user) {
-                    return $query;
-                })
                 ->query(function (Builder $query, Model $user) {
                     return $query;
                 }),
@@ -43,11 +40,8 @@ class PostControl extends Control
                 ->should(function (Model $user, Model $model) {
                     return $model->client()->is($user->client);
                 })
-                ->scoutQuery(function (\Laravel\Scout\Builder $query, Model $user) {
-                    return $query->where('client_id', $user->client->getKey());
-                })
                 ->query(function (Builder $query, Model $user) {
-                    return $query->orWhere('client_id', $user->client->getKey());
+                    return $query->where('client_id', $user->client->getKey());
                 }),
         // ...
 ```
@@ -55,7 +49,7 @@ class PostControl extends Control
 Then setup your policy:
 
 ```php
-    class PostPolicy extends ControlledPolicy
+class PostPolicy extends ControlledPolicy
 {
     protected string $model = Post::class;
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class PostControl extends Control
         // ...
 ```
 
-Then setup your policy:
+Then set up your policy:
 
 ```php
 class PostPolicy extends ControlledPolicy

--- a/src/Console/ControlMakeCommand.php
+++ b/src/Console/ControlMakeCommand.php
@@ -123,10 +123,10 @@ class ControlMakeCommand extends GeneratorCommand
 
             $perimetersImplementation .= <<<PERIMETER
             $perimeterClass::new()
-                    ->should(function (Model \$user, string \$method, Model \$model) {
+                    ->allowed(function (Model \$user, string \$method) {
                         return true;
                     })
-                    ->allowed(function (Model \$user) {
+                    ->should(function (Model \$user, Model \$model) {
                         return true;
                     })
                     ->query(function (Builder \$query, Model \$user) {

--- a/src/Console/ControlMakeCommand.php
+++ b/src/Console/ControlMakeCommand.php
@@ -122,8 +122,7 @@ class ControlMakeCommand extends GeneratorCommand
             $perimeterClass = $this->rootNamespace().'Access\\Perimeters\\'.$perimeter;
 
             $perimetersImplementation .= <<<PERIMETER
-                \\n
-                $perimeterClass::new()
+            $perimeterClass::new()
                     ->should(function (Model \$user, string \$method, Model \$model) {
                         return true;
                     })
@@ -132,7 +131,7 @@ class ControlMakeCommand extends GeneratorCommand
                     })
                     ->query(function (Builder \$query, Model \$user) {
                         return \$query;
-                    }),\\n
+                    }),
             PERIMETER;
         }
 

--- a/src/Console/stubs/control.stub
+++ b/src/Console/stubs/control.stub
@@ -17,6 +17,8 @@ class {{ class }} extends Control
      */
     protected function perimeters(): array
     {
-        return [{{ perimeters }}];
+        return [
+            {{ perimeters }}
+        ];
     }
 }


### PR DESCRIPTION
This PR Fix generates a control.

The “\n” are not interpreted in the heredoc syntax.

So I made the following changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting of generated code by removing unnecessary blank lines and adjusting indentation in code templates.
  - Refined array formatting in control stubs for better readability.
  - Updated query conditions and cleaned up indentation in example class definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->