### PR TITLE
Changes to published stub

### DIFF
--- a/src/AccessServiceProvider.php
+++ b/src/AccessServiceProvider.php
@@ -86,7 +86,7 @@ class AccessServiceProvider extends ServiceProvider
     protected function registerStubs()
     {
         Event::listen(function (PublishingStubs $event) {
-            $event->add(realpath(__DIR__.'/Console/stubs/control.stub'), 'controller.stub');
+            $event->add(realpath(__DIR__.'/Console/stubs/control.stub'), 'control.stub');
             $event->add(realpath(__DIR__.'/Console/stubs/perimeter.plain.stub'), 'perimeter.plain.stub');
             $event->add(realpath(__DIR__.'/Console/stubs/perimeter.overlay.stub'), 'perimeter.overlay.stub');
         });

--- a/tests/Unit/StubsTest.php
+++ b/tests/Unit/StubsTest.php
@@ -12,7 +12,7 @@ class StubsTest extends TestCase
 
         $this->assertEquals(
             [
-                realpath(__DIR__.'/../../src/Console/stubs/control.stub')           => 'controller.stub',
+                realpath(__DIR__.'/../../src/Console/stubs/control.stub')           => 'control.stub',
                 realpath(__DIR__.'/../../src/Console/stubs/perimeter.plain.stub')   => 'perimeter.plain.stub',
                 realpath(__DIR__.'/../../src/Console/stubs/perimeter.overlay.stub') => 'perimeter.overlay.stub',
             ],


### PR DESCRIPTION
The stub control.stub was published under the name “controller.stub”.
However, controller.stub corresponds to the Laravel stub for controllers, creating an inconsistency.

I renamed it to `control.stub`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the registration key for the control stub to match its actual filename, ensuring proper stub usage.
- **Tests**
  - Updated test assertions to reflect the corrected stub filename, improving test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->