### PR TITLE
Implicit binding model in policy

### DIFF
--- a/src/Policies/ControlledPolicy.php
+++ b/src/Policies/ControlledPolicy.php
@@ -27,7 +27,7 @@ class ControlledPolicy
             return $this->model;
         }
 
-        return "App\\Models\\" . str_replace('Policy', '', class_basename(static::class));
+        return 'App\\Models\\'.str_replace('Policy', '', class_basename(static::class));
     }
 
     /**


### PR DESCRIPTION
This allows the model name in `ControlledPolicy` to be determined directly. It is always possible to specify the name in special cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved policy handling by adding a fallback mechanism to automatically determine the associated model when not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->