### PR TITLE
🐛 has control scope

### DIFF
--- a/src/Controls/HasControl.php
+++ b/src/Controls/HasControl.php
@@ -21,7 +21,7 @@ trait HasControl
      *
      * @return Control|null The newly created control instance, or null if creation was unsuccessful.
      */
-    protected function newControl(): ?Control
+    public function newControl(): ?Control
     {
         return Access::controlForModel(static::class);
     }

--- a/tests/Feature/ControlsScopeTest.php
+++ b/tests/Feature/ControlsScopeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Lomkit\Access\Tests\Support\Models\Model;
+use Lomkit\Access\Tests\Support\Models\User;
+
+class ControlsScopeTest extends \Lomkit\Access\Tests\Feature\TestCase
+{
+    public function test_control_controlled_scope(): void
+    {
+        Model::factory()
+            ->count(50)
+            ->create();
+
+        $query = Model::controlled()->get();
+
+        $this->assertEquals(0, $query->count());
+    }
+
+    public function test_control_uncontrolled_scope(): void
+    {
+        Model::factory()
+            ->count(50)
+            ->create();
+
+        $query = Model::uncontrolled();
+
+        $this->assertContains(\Lomkit\Access\Controls\HasControlScope::class, $query->removedScopes());
+    }
+}

--- a/tests/Feature/ControlsScopeTest.php
+++ b/tests/Feature/ControlsScopeTest.php
@@ -1,10 +1,6 @@
 <?php
 
-
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Gate;
 use Lomkit\Access\Tests\Support\Models\Model;
-use Lomkit\Access\Tests\Support\Models\User;
 
 class ControlsScopeTest extends \Lomkit\Access\Tests\Feature\TestCase
 {


### PR DESCRIPTION
closes #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to verify the behavior of model query scopes related to control filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->