### PR TITLE
Update laravel/scout version constraint to include 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^6.0|^7.0",
-    "laravel/scout": "^10",
+    "laravel/scout": "^10|^11",
     "orchestra/testbench": "^9|^10|^11",
     "phpunit/phpunit": "^11.0|^12.0|^13.0"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency version constraints to support Laravel Scout versions 10 and 11, enabling compatibility with both major releases in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->